### PR TITLE
drop uniq index on (commit_sha, repo): id breaks case when pr is reop…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /vendor
 /golangci-api
 /*.log
+/logs/

--- a/app/migrations/15_drop_commit_sha_and_repo_uniq_index_from_github_analyzes.down.sql
+++ b/app/migrations/15_drop_commit_sha_and_repo_uniq_index_from_github_analyzes.down.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX github_analyzes_uniq_repo_and_commit_sha
+  ON github_analyzes(github_repo_id, commit_sha)
+  WHERE commit_sha != '';

--- a/app/migrations/15_drop_commit_sha_and_repo_uniq_index_from_github_analyzes.up.sql
+++ b/app/migrations/15_drop_commit_sha_and_repo_uniq_index_from_github_analyzes.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX github_analyzes_uniq_repo_and_commit_sha;

--- a/app/test/sharedtest/github_fake.go
+++ b/app/test/sharedtest/github_fake.go
@@ -113,7 +113,7 @@ func emailHandler(w http.ResponseWriter, r *http.Request) {
 
 func listReposHandler(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
-	if q.Get("visibility") != "public" || q.Get("sort") != "pushed" {
+	if (q.Get("visibility") != "public" && q.Get("visibility") != "all") || q.Get("sort") != "pushed" {
 		log.Printf("Invalid query params: %+v", q)
 		w.WriteHeader(http.StatusBadRequest)
 		return


### PR DESCRIPTION
…ened; we already have github_delivery_guid for duplication avoidance