### PR TITLE
Replace deprecated deadline flag with timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 2m
+  timeout: 2m
 
 linters-settings:
   govet:

--- a/pkg/goenvbuild/ensuredeps/ensure.go
+++ b/pkg/goenvbuild/ensuredeps/ensure.go
@@ -161,7 +161,7 @@ func (r *Runner) syncDeps(ctx context.Context, repoName string) error {
 
 func (r Runner) checkDeps(ctx context.Context, repoName string) error {
 	r.log.Infof("Checking deps...")
-	out, _ := r.cr.Run(ctx, "golangci-lint", "run", "--no-config", "--disable-all", "-E", "typecheck", "--deadline=5m")
+	out, _ := r.cr.Run(ctx, "golangci-lint", "run", "--no-config", "--disable-all", "-E", "typecheck", "--timeout=5m")
 	lines := strings.Split(out, "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(strings.ToLower(line))

--- a/pkg/goenvbuild/preparer.go
+++ b/pkg/goenvbuild/preparer.go
@@ -282,7 +282,7 @@ func parseVersion(v string) (*version, error) {
 
 func (p Preparer) runGolangciLint(ctx context.Context, sg *result.StepGroup, runner *command.StreamingRunner) error {
 	cmd := "golangci-lint"
-	args := []string{"run", "-v", "--deadline=5m"}
+	args := []string{"run", "-v", "--timeout=5m"}
 	sg.AddStepCmd(cmd, args...)
 	_, err := runner.Run(ctx, cmd, args...)
 	return err

--- a/pkg/worker/analyze/linters/golinters/golangci_lint.go
+++ b/pkg/worker/analyze/linters/golinters/golangci_lint.go
@@ -32,7 +32,7 @@ func (g GolangciLint) Run(ctx context.Context, sg *logresult.StepGroup, exec exe
 		"run",
 		"--out-format=json",
 		"--issues-exit-code=0",
-		"--deadline=5m",
+		"--timeout=5m",
 		"--new=false",
 		"--new-from-rev=",
 		"--new-from-patch=" + g.PatchPath,


### PR DESCRIPTION
The `--deadline` flag has been marked as deprecated in https://github.com/golangci/golangci-lint/pull/793. 