### PR TITLE
Add support for golangci-lint v1.22.x

### DIFF
--- a/pkg/goenvbuild/preparer.go
+++ b/pkg/goenvbuild/preparer.go
@@ -39,10 +39,11 @@ var availableGolangciLintVersions = map[int]map[int][]int{
 		19: {0, 1},
 		20: {0, 1},
 		21: {0},
+		22: {0, 1, 2},
 	},
 }
 
-const defaultGolangciLintVersion = "1.21.x"
+const defaultGolangciLintVersion = "1.22.x"
 
 type Preparer struct {
 	cfg config.Config


### PR DESCRIPTION
New versions of `golangci-lint` have just been released.  This PR is to hopefully add support for the new versions to golangci.com.

New versions:

- v1.22.0
- v1.22.1
- v1.22.2